### PR TITLE
docs(python): fix PyPI install command to dnse-sdk-openapi

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -27,11 +27,23 @@ and investment applications.
 
 #### Install from PyPI
 
+The package on PyPI is **`dnse-sdk-openapi`** (there is no package named `openapi-sdk`):
+
 ```console
-pip install openapi-sdk 
+pip install dnse-sdk-openapi
 ```
 
-Upgrade
+For WebSocket examples that use MessagePack encoding ([`websocket-marketdata/`](websocket-marketdata)):
+
+```console
+pip install dnse-sdk-openapi msgpack
+```
+
+Upgrade:
+
+```console
+pip install -U dnse-sdk-openapi
+```
 
 ### Usage
 


### PR DESCRIPTION
## Summary

The Python README instructs users to run `pip install openapi-sdk`, but **no package with that name exists on PyPI** ([404](https://pypi.org/project/openapi-sdk/)).

The published distribution for this repository's `python/dnse` package is **`dnse-sdk-openapi`**:
https://pypi.org/project/dnse-sdk-openapi/

This PR updates the install section accordingly and mentions `msgpack` for [`websocket-marketdata/`](https://github.com/dnse-tech/openapi-sdk/tree/main/python/websocket-marketdata) examples (MessagePack encoding).

## Changes

- `python/README.md`: replace `pip install openapi-sdk` with `pip install dnse-sdk-openapi`
- Add optional `msgpack` install note for WebSocket examples
- Add upgrade command example

## Test plan

- [x] Verified `pip install dnse-sdk-openapi` installs `dnse` with `DNSEClient` and `TradingClient`
- [x] Confirmed `pip install openapi-sdk` fails on PyPI


Made with [Cursor](https://cursor.com)